### PR TITLE
redITEM CTA Module integration

### DIFF
--- a/component/libraries/redform/core/core.php
+++ b/component/libraries/redform/core/core.php
@@ -440,6 +440,11 @@ class RdfCore extends JObject
 			$html .= '<input type="hidden" name="submit_key" value="' . $submit_key . '" />';
 		}
 
+		if (isset($options['module_id']))
+		{
+			$html .= '<input type="hidden" name="module_id" value="' . $options['module_id'] . '" />';
+		}
+
 		$html .= '<input type="hidden" name="nbactive" value="' . $initialActive . '" />';
 		$html .= '<input type="hidden" name="form_id" value="' . $form_id . '" />';
 		$html .= '<input type="hidden" name="multi" value="' . $multi . '" />';

--- a/component/libraries/redform/core/form/submission.php
+++ b/component/libraries/redform/core/form/submission.php
@@ -20,6 +20,8 @@ class RdfCoreFormSubmission
 {
 	protected $formId;
 
+	protected $moduleId;
+
 	protected $formModel;
 
 	protected $submitKey;
@@ -53,6 +55,9 @@ class RdfCoreFormSubmission
 		{
 			case 'submit_key':
 				return $this->submitKey;
+
+			case 'module_id':
+				return $this->moduleId;
 
 			case 'posts':
 				$posts = array();
@@ -103,6 +108,7 @@ class RdfCoreFormSubmission
 		{
 			$data = array();
 			$data['form_id'] = $app->input->getInt('form_id', 0);
+			$data['module_id'] = $app->input->getInt('module_id', 0);
 			$data['submit_key'] = $app->input->getCmd('submit_key', false);
 			$data['nbactive'] = $app->input->getInt('nbactive', 1);
 			$data['currency'] = $app->input->getCmd('currency', '');
@@ -123,6 +129,11 @@ class RdfCoreFormSubmission
 		}
 
 		$this->setSubmitKey($submit_key);
+
+		if (isset($data['module_id']))
+		{
+			$this->moduleId = $data['module_id'];
+		}
 
 		/* Get the form details */
 		$this->formId = $data['form_id'];

--- a/component/plugins/content/redform/redform.php
+++ b/component/plugins/content/redform/redform.php
@@ -116,7 +116,14 @@ class PlgContentRedform extends JPlugin
 			return JText::_('COM_REDFORM_No_active_form_found');
 		}
 
-		return $this->rfcore->displayForm($form->id, null, $multiple);
+		$options = array();
+
+		if (isset($this->rwfparams['module_id']))
+		{
+			$options['module_id'] = $this->rwfparams['module_id'];
+		}
+
+		return $this->rfcore->displayForm($form->id, null, $multiple, $options);
 	}
 
 	/**


### PR DESCRIPTION
This PR allows modules to pass their id to `onContentPrepare` params which is carried around so we can know from which Joomla module the form was submitted.

Here an example of integration with redITEM CTA Module system which tracks form submissions:

https://github.com/florianv/redITEM2/blob/redform/plugins/redform/reditem_cta_module/reditem_cta_module.php#L29
