### PR TITLE
[fix] TypeError: $ is not a function

### DIFF
--- a/component/media/com_redform/js/redform-validate.js
+++ b/component/media/com_redform/js/redform-validate.js
@@ -226,7 +226,7 @@ var RedFormValidator = function() {
 	};
 
 	// Initialize handlers and attach validation to form
- 	$(function() {
+ 	jQuery(function() {
  	 	inputEmail = (function() {
  	 	 	var input = document.createElement("input");
  	 	 	input.setAttribute("type", "email");


### PR DESCRIPTION
This commit caused Aesir tests to be broken:

https://github.com/redCOMPONENT-COM/redFORM/commit/3932a2e65f0b1ea2d94df28ed2544f621c37c720

![redform-js](https://cloud.githubusercontent.com/assets/1119272/20637118/bf1c769a-b37c-11e6-8cf2-bdb28b562ff9.jpg)

Probably it should be a:

```js
(function($){
    // Use $ happily here
})(jQuery);
```

But I just want to unblock failing PRs